### PR TITLE
:bug: TypeError: can only concatenate str (not "int") to str

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -24,11 +24,12 @@ response = client.publish_layer_version(
 layer_arn = response['LayerArn']
 layer_version_arn = response['LayerVersionArn']
 layer_version = response['Version']
+statement_id = layer_name + '_' + layer_version
 
 response = client.add_layer_version_permission(
     LayerName=layer_arn,
     VersionNumber=layer_version,
-    StatementId=layer_name + "_" + layer_version,
+    StatementId=statement_id,
     Action='lambda:GetLayerVersion',
     Principal='*'
 )


### PR DESCRIPTION
Fix Error

https://circleci.com/gh/umisora/awesome-aws-sdk-lambda-layer/36

```
Upload boto3-19173 to lambda layer
Traceback (most recent call last):
  File "deploy.py", line 31, in <module>
    StatementId=layer_name + "_" + layer_version,
TypeError: can only concatenate str (not "int") to str
Exited with code 1
```
