### PR TITLE
TypeError: can only concatenate str (not "int") to str

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -24,7 +24,7 @@ response = client.publish_layer_version(
 layer_arn = response['LayerArn']
 layer_version_arn = response['LayerVersionArn']
 layer_version = response['Version']
-statement_id = layer_name + '_' + layer_version
+statement_id = layer_name + '_' + str(layer_version)
 
 response = client.add_layer_version_permission(
     LayerName=layer_arn,


### PR DESCRIPTION
:bug: TypeError: can only concatenate str (not "int") to str by umisora · Pull Request #3 · umisora/awesome-aws-sdk-lambda-layer https://github.com/umisora/awesome-aws-sdk-lambda-layer/pull/3

Part 2 ... 😢 